### PR TITLE
Fit the linter and formatter configuration to standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,4 @@ root = true
 
 [*.{kt,kts}]
 ktlint_function_naming_ignore_when_annotated_with = Composable
+ktlint_property_naming_constant_naming = pascal_case

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,4 @@
 root = true
 
 [*.{kt,kts}]
-ktlint_function_naming_ignore_when_annotated_with=Composable
-
-[**/main.kt]
-ktlint_standard_filename = disabled
+ktlint_function_naming_ignore_when_annotated_with = Composable

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -16,11 +16,11 @@ plugins {
 
 detekt {
     buildUponDefaultConfig = true
-    allRules = false
-    // Use true if we want all rules, but default rules are usually
-    // enough to catch UnusedPrivateMember and EmptyFunctionBlock.
     config.setFrom(file("../detekt.yml"))
-    baseline = file("detekt-baseline.xml")
+    // The plain detekt task only knows the default JVM layout (src/main/kotlin
+    // etc.), which does not exist in a KMP project, so point it at all source
+    // sets. Without this the detekt task analyzes no files at all.
+    source.setFrom("src")
 }
 
 kotlin {

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/components/listItems/PortfolioItemIcon.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/components/listItems/PortfolioItemIcon.kt
@@ -25,6 +25,22 @@ import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
 import dev.yuyuyuyuyu.portfolio.utils.displayName
 import org.jetbrains.compose.resources.painterResource
 
+// Gruvbox Light palette for the terminal-window style box
+private val TerminalBackgroundColor = Color(0xFFFBF1C7)
+private val TerminalPromptColor = Color(0xFF3C3836)
+private val WindowCloseButtonColor = Color(0xFFCC241D)
+private val WindowMinimizeButtonColor = Color(0xFFD79921)
+private val WindowZoomButtonColor = Color(0xFF98971A)
+
+// Dimensions expressed as fractions of the icon size
+private const val AppCornerRatio = 6f
+private const val TerminalCornerRatio = 8f
+private const val TerminalPaddingRatio = 10f
+private const val WindowButtonSpacingRatio = 20f
+private const val WindowButtonSizeRatio = 12f
+private const val PromptFontRatio = 8f
+private const val PromptLineHeightRatio = 6f
+
 @Composable
 fun PortfolioItemIcon(
     item: PortfolioItem,
@@ -38,7 +54,7 @@ fun PortfolioItemIcon(
             modifier =
                 modifier
                     .size(size)
-                    .clip(RoundedCornerShape(size / 6f)),
+                    .clip(RoundedCornerShape(size / AppCornerRatio)),
             contentScale = ContentScale.Crop,
         )
     } else {
@@ -47,28 +63,28 @@ fun PortfolioItemIcon(
             modifier =
                 modifier
                     .size(size)
-                    .clip(RoundedCornerShape(size / 8f))
-                    .background(Color(0xFFFBF1C7))
-                    .padding(size / 10f),
+                    .clip(RoundedCornerShape(size / TerminalCornerRatio))
+                    .background(TerminalBackgroundColor)
+                    .padding(size / TerminalPaddingRatio),
         ) {
             // macOS Window Buttons
             Row(
-                horizontalArrangement = Arrangement.spacedBy(size / 20f),
-                modifier = Modifier.padding(bottom = size / 10f),
+                horizontalArrangement = Arrangement.spacedBy(size / WindowButtonSpacingRatio),
+                modifier = Modifier.padding(bottom = size / TerminalPaddingRatio),
             ) {
-                Box(modifier = Modifier.size(size / 12f).clip(CircleShape).background(Color(0xFFCC241D)))
-                Box(modifier = Modifier.size(size / 12f).clip(CircleShape).background(Color(0xFFD79921)))
-                Box(modifier = Modifier.size(size / 12f).clip(CircleShape).background(Color(0xFF98971A)))
+                Box(modifier = Modifier.size(size / WindowButtonSizeRatio).clip(CircleShape).background(WindowCloseButtonColor))
+                Box(modifier = Modifier.size(size / WindowButtonSizeRatio).clip(CircleShape).background(WindowMinimizeButtonColor))
+                Box(modifier = Modifier.size(size / WindowButtonSizeRatio).clip(CircleShape).background(WindowZoomButtonColor))
             }
 
             // Terminal Prompt
             Text(
                 text = "> ${item.displayName}",
-                color = Color(0xFF3C3836),
-                fontSize = (size.value / 8f).sp,
+                color = TerminalPromptColor,
+                fontSize = (size.value / PromptFontRatio).sp,
                 maxLines = 4,
                 overflow = TextOverflow.Ellipsis,
-                lineHeight = (size.value / 6f).sp,
+                lineHeight = (size.value / PromptLineHeightRatio).sp,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/PortfolioNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/PortfolioNavigation.kt
@@ -8,32 +8,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModel
 import dev.yuyuyuyuyu.portfolio.ui.portfolio.catalog.CatalogScreen
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModel
 import dev.yuyuyuyuyu.portfolio.ui.portfolio.detail.DetailScreen
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.libraries.LibrariesViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModel
 import dev.yuyuyuyuyu.portfolio.ui.portfolio.search.SearchScreen
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModel
 import dev.yuyuyuyuyu.portfolio.ui.portfolio.today.TodayScreen
 
 @Composable
 fun PortfolioNavigation(
     backStack: MutableList<PortfolioRoute>,
-    appsViewModel: AppsViewModel,
-    librariesViewModel: LibrariesViewModel,
-    pluginsViewModel: PluginsViewModel,
-    cliToolsViewModel: CliToolsViewModel,
-    templatesViewModel: TemplatesViewModel,
+    viewModels: PortfolioViewModels,
     modifier: Modifier = Modifier,
 ) {
-    val appsState by appsViewModel.uiState.collectAsState()
-    val librariesState by librariesViewModel.uiState.collectAsState()
-    val pluginsState by pluginsViewModel.uiState.collectAsState()
-    val cliToolsState by cliToolsViewModel.uiState.collectAsState()
-    val templatesState by templatesViewModel.uiState.collectAsState()
-
     NavDisplay(
         backStack = backStack,
         modifier = modifier,
@@ -43,10 +28,7 @@ fun PortfolioNavigation(
                 PortfolioRoute.Today ->
                     NavEntry(key) {
                         TodayScreen(
-                            appsViewModel = appsViewModel,
-                            pluginsViewModel = pluginsViewModel,
-                            cliToolsViewModel = cliToolsViewModel,
-                            templatesViewModel = templatesViewModel,
+                            viewModels = viewModels,
                             onProductClick = { url -> backStack.add(PortfolioRoute.Detail(url)) },
                         )
                     }
@@ -54,11 +36,7 @@ fun PortfolioNavigation(
                 PortfolioRoute.Catalog ->
                     NavEntry(key) {
                         CatalogScreen(
-                            appsViewModel = appsViewModel,
-                            librariesViewModel = librariesViewModel,
-                            pluginsViewModel = pluginsViewModel,
-                            cliToolsViewModel = cliToolsViewModel,
-                            templatesViewModel = templatesViewModel,
+                            viewModels = viewModels,
                             onProductClick = { url -> backStack.add(PortfolioRoute.Detail(url)) },
                         )
                     }
@@ -66,33 +44,45 @@ fun PortfolioNavigation(
                 PortfolioRoute.Search ->
                     NavEntry(key) {
                         SearchScreen(
-                            appsViewModel = appsViewModel,
-                            librariesViewModel = librariesViewModel,
-                            pluginsViewModel = pluginsViewModel,
-                            cliToolsViewModel = cliToolsViewModel,
-                            templatesViewModel = templatesViewModel,
+                            viewModels = viewModels,
                             onProductClick = { url -> backStack.add(PortfolioRoute.Detail(url)) },
                         )
                     }
 
                 is PortfolioRoute.Detail ->
                     NavEntry(key) {
-                        val url = key.repositoryUrl
-                        val allItems =
-                            appsState.apps + librariesState.libraries + pluginsState.plugins +
-                                cliToolsState.cliTools + templatesState.templates
-                        val item = allItems.find { it.repositoryUrl == url }
-
-                        if (item != null) {
-                            DetailScreen(item = item)
-                        } else {
-                            // Fallback or error state
-                            Text("Item not found")
-                        }
+                        DetailEntry(
+                            viewModels = viewModels,
+                            repositoryUrl = key.repositoryUrl,
+                        )
                     }
             }
         },
     )
+}
+
+@Composable
+private fun DetailEntry(
+    viewModels: PortfolioViewModels,
+    repositoryUrl: String,
+) {
+    val appsState by viewModels.apps.uiState.collectAsState()
+    val librariesState by viewModels.libraries.uiState.collectAsState()
+    val pluginsState by viewModels.plugins.uiState.collectAsState()
+    val cliToolsState by viewModels.cliTools.uiState.collectAsState()
+    val templatesState by viewModels.templates.uiState.collectAsState()
+
+    val allItems =
+        appsState.apps + librariesState.libraries + pluginsState.plugins +
+            cliToolsState.cliTools + templatesState.templates
+    val item = allItems.find { it.repositoryUrl == repositoryUrl }
+
+    if (item != null) {
+        DetailScreen(item = item)
+    } else {
+        // Fallback or error state
+        Text("Item not found")
+    }
 }
 
 @Preview

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/PortfolioScreen.kt
@@ -31,11 +31,7 @@ typealias PortfolioScreen = @Composable (onNavigateToLicenses: () -> Unit) -> Un
 @Inject
 @Composable
 fun PortfolioScreen(
-    appsViewModel: dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModelImpl,
-    librariesViewModel: dev.yuyuyuyuyu.portfolio.ui.portfolio.libraries.LibrariesViewModelImpl,
-    pluginsViewModel: dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModelImpl,
-    cliToolsViewModel: dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModelImpl,
-    templatesViewModel: dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModelImpl,
+    viewModels: PortfolioViewModels,
     @me.tatarka.inject.annotations.Assisted onNavigateToLicenses: () -> Unit,
 ) {
     val backStack: MutableList<PortfolioRoute> =
@@ -102,11 +98,7 @@ fun PortfolioScreen(
     ) { innerPadding ->
         PortfolioNavigation(
             backStack = backStack,
-            appsViewModel = appsViewModel,
-            librariesViewModel = librariesViewModel,
-            pluginsViewModel = pluginsViewModel,
-            cliToolsViewModel = cliToolsViewModel,
-            templatesViewModel = templatesViewModel,
+            viewModels = viewModels,
             modifier = Modifier.padding(innerPadding),
         )
     }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/PortfolioViewModels.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/PortfolioViewModels.kt
@@ -1,0 +1,32 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio
+
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModel
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModel
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.libraries.LibrariesViewModel
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.libraries.LibrariesViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModel
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModel
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModelImpl
+import me.tatarka.inject.annotations.Inject
+
+/**
+ * The view models shared by the portfolio screens, grouped so that they can
+ * travel through the navigation graph as a single parameter.
+ */
+@Inject
+class PortfolioViewModels(
+    apps: AppsViewModelImpl,
+    libraries: LibrariesViewModelImpl,
+    plugins: PluginsViewModelImpl,
+    cliTools: CliToolsViewModelImpl,
+    templates: TemplatesViewModelImpl,
+) {
+    val apps: AppsViewModel = apps
+    val libraries: LibrariesViewModel = libraries
+    val plugins: PluginsViewModel = plugins
+    val cliTools: CliToolsViewModel = cliTools
+    val templates: TemplatesViewModel = templates
+}

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogScreen.kt
@@ -17,12 +17,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.yuyuyuyuyu.portfolio.data.models.Platform
+import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
 import dev.yuyuyuyuyu.portfolio.data.models.ProductCategory
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.libraries.LibrariesViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModel
+import dev.yuyuyuyuyu.portfolio.ui.components.listItems.PortfolioItemTile
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.PortfolioViewModels
 import org.jetbrains.compose.resources.stringResource
 import portfolio.composeapp.generated.resources.Res
 import portfolio.composeapp.generated.resources.ui_cli_tools
@@ -35,18 +33,14 @@ import portfolio.composeapp.generated.resources.ui_web_apps
 
 @Composable
 fun CatalogScreen(
-    appsViewModel: AppsViewModel,
-    librariesViewModel: LibrariesViewModel,
-    pluginsViewModel: PluginsViewModel,
-    cliToolsViewModel: CliToolsViewModel,
-    templatesViewModel: TemplatesViewModel,
+    viewModels: PortfolioViewModels,
     onProductClick: (String) -> Unit,
 ) {
-    val appsState by appsViewModel.uiState.collectAsState()
-    val librariesState by librariesViewModel.uiState.collectAsState()
-    val pluginsState by pluginsViewModel.uiState.collectAsState()
-    val cliToolsState by cliToolsViewModel.uiState.collectAsState()
-    val templatesState by templatesViewModel.uiState.collectAsState()
+    val appsState by viewModels.apps.uiState.collectAsState()
+    val librariesState by viewModels.libraries.uiState.collectAsState()
+    val pluginsState by viewModels.plugins.uiState.collectAsState()
+    val cliToolsState by viewModels.cliTools.uiState.collectAsState()
+    val templatesState by viewModels.templates.uiState.collectAsState()
 
     CatalogScreenContent(
         allApps = appsState.apps,
@@ -57,8 +51,8 @@ fun CatalogScreen(
 
 @Composable
 fun CatalogScreenContent(
-    allApps: List<dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem>,
-    allProducts: List<dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem>,
+    allApps: List<PortfolioItem>,
+    allProducts: List<PortfolioItem>,
     onProductClick: (String) -> Unit,
 ) {
     // Group apps
@@ -73,78 +67,31 @@ fun CatalogScreenContent(
     val libraries = allProducts.filter { it.category == ProductCategory.Library }.sortedBy { it.nameFallback }
     val templates = allProducts.filter { it.category == ProductCategory.Template }.sortedBy { it.nameFallback }
 
+    val sections =
+        listOf(
+            Res.string.ui_web_apps to webApps,
+            Res.string.ui_plugins to plugins,
+            Res.string.ui_libraries to libraries,
+            Res.string.ui_cli_tools to cliTools,
+            Res.string.ui_templates to templates,
+            Res.string.ui_mac_apps to macApps,
+            Res.string.ui_mobile_other_apps to (androidIosApps + otherApps),
+        )
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(32.dp),
     ) {
-        if (webApps.isNotEmpty()) {
-            item {
-                CatalogSection(
-                    title = stringResource(Res.string.ui_web_apps),
-                    items = webApps,
-                    onProductClick = onProductClick,
-                )
-            }
-        }
-
-        if (plugins.isNotEmpty()) {
-            item {
-                CatalogSection(
-                    title = stringResource(Res.string.ui_plugins),
-                    items = plugins,
-                    onProductClick = onProductClick,
-                )
-            }
-        }
-
-        if (libraries.isNotEmpty()) {
-            item {
-                CatalogSection(
-                    title = stringResource(Res.string.ui_libraries),
-                    items = libraries,
-                    onProductClick = onProductClick,
-                )
-            }
-        }
-
-        if (cliTools.isNotEmpty()) {
-            item {
-                CatalogSection(
-                    title = stringResource(Res.string.ui_cli_tools),
-                    items = cliTools,
-                    onProductClick = onProductClick,
-                )
-            }
-        }
-
-        if (templates.isNotEmpty()) {
-            item {
-                CatalogSection(
-                    title = stringResource(Res.string.ui_templates),
-                    items = templates,
-                    onProductClick = onProductClick,
-                )
-            }
-        }
-
-        if (macApps.isNotEmpty()) {
-            item {
-                CatalogSection(
-                    title = stringResource(Res.string.ui_mac_apps),
-                    items = macApps,
-                    onProductClick = onProductClick,
-                )
-            }
-        }
-
-        if (androidIosApps.isNotEmpty() || otherApps.isNotEmpty()) {
-            item {
-                CatalogSection(
-                    title = stringResource(Res.string.ui_mobile_other_apps),
-                    items = androidIosApps + otherApps,
-                    onProductClick = onProductClick,
-                )
+        sections.forEach { (titleRes, sectionItems) ->
+            if (sectionItems.isNotEmpty()) {
+                item {
+                    CatalogSection(
+                        title = stringResource(titleRes),
+                        items = sectionItems,
+                        onProductClick = onProductClick,
+                    )
+                }
             }
         }
     }
@@ -153,7 +100,7 @@ fun CatalogScreenContent(
 @Composable
 fun CatalogSection(
     title: String,
-    items: List<dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem>,
+    items: List<PortfolioItem>,
     onProductClick: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -168,7 +115,7 @@ fun CatalogSection(
             contentPadding = PaddingValues(horizontal = 16.dp),
         ) {
             items(items) { item ->
-                dev.yuyuyuyuyu.portfolio.ui.components.listItems.PortfolioItemTile(
+                PortfolioItemTile(
                     item = item,
                     onClick = { onProductClick(item.repositoryUrl) },
                 )

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/detail/DetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/detail/DetailScreen.kt
@@ -60,17 +60,7 @@ import portfolio.composeapp.generated.resources.ui_why_built
 
 @Composable
 fun DetailScreen(item: PortfolioItem) {
-    val uriHandler = LocalUriHandler.current
-    val clipboard = LocalClipboard.current
-    val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
-
-    val name = item.displayName
-    val description = item.displayDescription
-    val motivation = item.displayMotivation
-    val repositoryUrl = item.repositoryUrl
-    val installCommand = item.installCommand
-    val appUrl = (item as? App)?.url
 
     Column(
         modifier =
@@ -80,132 +70,154 @@ fun DetailScreen(item: PortfolioItem) {
                 .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(32.dp),
     ) {
-        // --- Header Section ---
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(24.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            PortfolioItemIcon(item = item, size = 120.dp)
-
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(
-                    text = name,
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.Bold,
-                )
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-
-                // Action Buttons
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.padding(top = 8.dp)) {
-                    if (appUrl != null) {
-                        Button(onClick = { uriHandler.openUri(appUrl) }) {
-                            Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null, modifier = Modifier.size(18.dp))
-                            Spacer(Modifier.width(8.dp))
-                            Text(stringResource(Res.string.ui_open))
-                        }
-                    }
-                    OutlinedButton(onClick = { uriHandler.openUri(repositoryUrl) }) {
-                        Icon(Icons.Default.Code, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(Modifier.width(8.dp))
-                        Text("GitHub")
-                    }
-                }
-            }
-        }
+        DetailHeader(item = item)
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
-        // --- Screenshots Section (Only for Apps) ---
         if (item is App && item.screenshots.isNotEmpty()) {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                Text(
-                    text = stringResource(Res.string.ui_screenshots),
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-                LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                    items(item.screenshots) { screenshot ->
-                        Image(
-                            painter = painterResource(screenshot),
-                            contentDescription = "Screenshot of $name",
-                            modifier =
-                                Modifier
-                                    .height(400.dp)
-                                    .clip(RoundedCornerShape(12.dp)),
-                            contentScale = ContentScale.Fit,
-                        )
-                    }
-                }
-            }
+            ScreenshotsSection(app = item)
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
         }
 
-        // --- Motivation / Story Section ---
+        val motivation = item.displayMotivation
         if (!motivation.isNullOrBlank()) {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                Text(
-                    text = stringResource(Res.string.ui_why_built),
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-                Text(
-                    text = motivation,
-                    style = MaterialTheme.typography.bodyLarge,
-                    lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.5,
-                )
-            }
+            MotivationSection(motivation = motivation)
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
         }
 
-        // --- Install/Run Command Section ---
+        val installCommand = item.installCommand
         if (!installCommand.isNullOrBlank()) {
-            val commandTitle =
-                if (installCommand.trim().startsWith(
-                        "npx",
-                    )
-                ) {
-                    stringResource(Res.string.ui_run_command)
-                } else {
-                    stringResource(Res.string.ui_installation)
-                }
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-                Text(
-                    text = commandTitle,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-                Surface(
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceVariant,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
-                        SelectionContainer(modifier = Modifier.fillMaxWidth().padding(end = 48.dp)) {
-                            Text(
-                                text = installCommand,
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.padding(16.dp),
-                            )
-                        }
-                        IconButton(
-                            onClick = {
-                                coroutineScope.launch {
-                                    clipboard.setPlainText(installCommand)
-                                }
-                            },
-                            modifier = Modifier.padding(8.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.ContentCopy,
-                                contentDescription = stringResource(Res.string.ui_copy_command),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
+            InstallCommandSection(installCommand = installCommand)
+        }
+    }
+}
+
+@Composable
+private fun DetailHeader(item: PortfolioItem) {
+    val uriHandler = LocalUriHandler.current
+    val appUrl = (item as? App)?.url
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        PortfolioItemIcon(item = item, size = 120.dp)
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = item.displayName,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = item.displayDescription,
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // Action Buttons
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.padding(top = 8.dp)) {
+                if (appUrl != null) {
+                    Button(onClick = { uriHandler.openUri(appUrl) }) {
+                        Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(Res.string.ui_open))
                     }
+                }
+                OutlinedButton(onClick = { uriHandler.openUri(item.repositoryUrl) }) {
+                    Icon(Icons.Default.Code, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("GitHub")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScreenshotsSection(app: App) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            text = stringResource(Res.string.ui_screenshots),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            items(app.screenshots) { screenshot ->
+                Image(
+                    painter = painterResource(screenshot),
+                    contentDescription = "Screenshot of ${app.displayName}",
+                    modifier =
+                        Modifier
+                            .height(400.dp)
+                            .clip(RoundedCornerShape(12.dp)),
+                    contentScale = ContentScale.Fit,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MotivationSection(motivation: String) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            text = stringResource(Res.string.ui_why_built),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = motivation,
+            style = MaterialTheme.typography.bodyLarge,
+            lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.5,
+        )
+    }
+}
+
+@Composable
+private fun InstallCommandSection(installCommand: String) {
+    val clipboard = LocalClipboard.current
+    val coroutineScope = rememberCoroutineScope()
+
+    val commandTitle =
+        if (installCommand.trim().startsWith("npx")) {
+            stringResource(Res.string.ui_run_command)
+        } else {
+            stringResource(Res.string.ui_installation)
+        }
+
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        Text(
+            text = commandTitle,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+                SelectionContainer(modifier = Modifier.fillMaxWidth().padding(end = 48.dp)) {
+                    Text(
+                        text = installCommand,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+                IconButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            clipboard.setPlainText(installCommand)
+                        }
+                    },
+                    modifier = Modifier.padding(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ContentCopy,
+                        contentDescription = stringResource(Res.string.ui_copy_command),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchScreen.kt
@@ -43,11 +43,7 @@ import dev.yuyuyuyuyu.portfolio.data.models.Platform
 import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
 import dev.yuyuyuyuyu.portfolio.data.models.ProductCategory
 import dev.yuyuyuyuyu.portfolio.ui.components.listItems.PortfolioItemIcon
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.libraries.LibrariesViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModel
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.PortfolioViewModels
 import dev.yuyuyuyuyu.portfolio.utils.displayDescription
 import dev.yuyuyuyuyu.portfolio.utils.displayName
 import org.jetbrains.compose.resources.stringResource
@@ -57,21 +53,16 @@ import portfolio.composeapp.generated.resources.ui_no_results
 import portfolio.composeapp.generated.resources.ui_search
 import portfolio.composeapp.generated.resources.ui_search_placeholder
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(
-    appsViewModel: AppsViewModel,
-    librariesViewModel: LibrariesViewModel,
-    pluginsViewModel: PluginsViewModel,
-    cliToolsViewModel: CliToolsViewModel,
-    templatesViewModel: TemplatesViewModel,
+    viewModels: PortfolioViewModels,
     onProductClick: (String) -> Unit,
 ) {
-    val appsState by appsViewModel.uiState.collectAsState()
-    val librariesState by librariesViewModel.uiState.collectAsState()
-    val pluginsState by pluginsViewModel.uiState.collectAsState()
-    val cliToolsState by cliToolsViewModel.uiState.collectAsState()
-    val templatesState by templatesViewModel.uiState.collectAsState()
+    val appsState by viewModels.apps.uiState.collectAsState()
+    val librariesState by viewModels.libraries.uiState.collectAsState()
+    val pluginsState by viewModels.plugins.uiState.collectAsState()
+    val cliToolsState by viewModels.cliTools.uiState.collectAsState()
+    val templatesState by viewModels.templates.uiState.collectAsState()
 
     // Map all items to a common data structure (PortfolioItem)
     val allItems =
@@ -86,7 +77,6 @@ fun SearchScreen(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreenContent(
     allItems: List<PortfolioItem>,
@@ -124,78 +114,120 @@ fun SearchScreenContent(
             }.map { it.first }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        // Search Bar
-        OutlinedTextField(
-            value = searchQuery,
-            onValueChange = { searchQuery = it },
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-            placeholder = { Text(stringResource(Res.string.ui_search_placeholder)) },
-            leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(Res.string.ui_search)) },
-            trailingIcon = {
-                if (searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { searchQuery = "" }) {
-                        Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.ui_clear))
-                    }
-                }
-            },
-            singleLine = true,
-            // Pill shape
-            shape = RoundedCornerShape(100),
+        SearchQueryField(
+            query = searchQuery,
+            onQueryChange = { searchQuery = it },
         )
 
-        // Filters (Categories & Platforms)
-        LazyRow(
-            contentPadding = PaddingValues(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.padding(bottom = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            // Category filters
-            items(ProductCategory.entries.toTypedArray()) { category ->
-                FilterChip(
-                    selected = selectedCategory == category,
-                    onClick = { selectedCategory = if (selectedCategory == category) null else category },
-                    label = { Text(stringResource(category.labelRes)) },
-                )
-            }
-
-            item {
-                VerticalDivider(modifier = Modifier.height(24.dp).padding(horizontal = 8.dp))
-            }
-
-            // Important platform filters
-            val commonPlatforms = listOf(Platform.MacOS, Platform.Web, Platform.Android, Platform.Ios)
-            items(commonPlatforms) { platform ->
-                FilterChip(
-                    selected = selectedPlatform == platform,
-                    onClick = { selectedPlatform = if (selectedPlatform == platform) null else platform },
-                    label = { Text(platform.label) },
-                )
-            }
-        }
+        SearchFilterRow(
+            selectedCategory = selectedCategory,
+            onCategoryClick = { category ->
+                selectedCategory = if (selectedCategory == category) null else category
+            },
+            selectedPlatform = selectedPlatform,
+            onPlatformClick = { platform ->
+                selectedPlatform = if (selectedPlatform == platform) null else platform
+            },
+        )
 
         HorizontalDivider()
 
-        // Results List
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            if (filteredItems.isEmpty()) {
-                item {
-                    Box(modifier = Modifier.fillMaxWidth().padding(top = 64.dp), contentAlignment = Alignment.Center) {
-                        Text(
-                            stringResource(Res.string.ui_no_results),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
+        SearchResults(
+            filteredItems = filteredItems,
+            onProductClick = onProductClick,
+        )
+    }
+}
+
+@Composable
+private fun SearchQueryField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        placeholder = { Text(stringResource(Res.string.ui_search_placeholder)) },
+        leadingIcon = { Icon(Icons.Default.Search, contentDescription = stringResource(Res.string.ui_search)) },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.ui_clear))
                 }
-            } else {
-                items(filteredItems) { item ->
-                    SearchResultItem(item = item, onClick = { onProductClick(item.repositoryUrl) })
+            }
+        },
+        singleLine = true,
+        // Pill shape
+        shape = RoundedCornerShape(percent = 100),
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SearchFilterRow(
+    selectedCategory: ProductCategory?,
+    onCategoryClick: (ProductCategory) -> Unit,
+    selectedPlatform: Platform?,
+    onPlatformClick: (Platform) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.padding(bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Category filters
+        items(ProductCategory.entries.toTypedArray()) { category ->
+            FilterChip(
+                selected = selectedCategory == category,
+                onClick = { onCategoryClick(category) },
+                label = { Text(stringResource(category.labelRes)) },
+            )
+        }
+
+        item {
+            VerticalDivider(modifier = Modifier.height(24.dp).padding(horizontal = 8.dp))
+        }
+
+        // Important platform filters
+        val commonPlatforms = listOf(Platform.MacOS, Platform.Web, Platform.Android, Platform.Ios)
+        items(commonPlatforms) { platform ->
+            FilterChip(
+                selected = selectedPlatform == platform,
+                onClick = { onPlatformClick(platform) },
+                label = { Text(platform.label) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchResults(
+    filteredItems: List<PortfolioItem>,
+    onProductClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        if (filteredItems.isEmpty()) {
+            item {
+                Box(modifier = Modifier.fillMaxWidth().padding(top = 64.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        stringResource(Res.string.ui_no_results),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
+            }
+        } else {
+            items(filteredItems) { item ->
+                SearchResultItem(item = item, onClick = { onProductClick(item.repositoryUrl) })
             }
         }
     }
@@ -236,7 +268,7 @@ private fun SearchResultItem(
         // Category Label
         Surface(
             color = MaterialTheme.colorScheme.secondaryContainer,
-            shape = RoundedCornerShape(100),
+            shape = RoundedCornerShape(percent = 100),
             modifier = Modifier.align(Alignment.Top),
         ) {
             Text(

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/today/TodayFeaturedItems.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/today/TodayFeaturedItems.kt
@@ -1,0 +1,17 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio.today
+
+import dev.yuyuyuyuyu.portfolio.data.models.App
+import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
+
+/**
+ * The hand-picked items highlighted on the Today screen. Every entry is
+ * nullable because the catalog data may not contain the item (yet).
+ */
+data class TodayFeaturedItems(
+    val howOldAmI: App? = null,
+    val html2pdf: PortfolioItem? = null,
+    val notPullingCalc: App? = null,
+    val inputSourceHandler: App? = null,
+    val composePwa: PortfolioItem? = null,
+    val businessCard: PortfolioItem? = null,
+)

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/today/TodayScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/today/TodayScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Code
@@ -33,16 +34,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.yuyuyuyuyu.portfolio.data.models.App
 import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModel
-import dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModel
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.PortfolioViewModels
 import dev.yuyuyuyuyu.portfolio.utils.displayDescription
 import dev.yuyuyuyuyu.portfolio.utils.displayName
 import org.jetbrains.compose.resources.painterResource
@@ -66,34 +65,27 @@ import portfolio.composeapp.generated.resources.ui_ultimate_laziness
 
 @Composable
 fun TodayScreen(
-    appsViewModel: AppsViewModel,
-    pluginsViewModel: PluginsViewModel,
-    cliToolsViewModel: CliToolsViewModel,
-    templatesViewModel: TemplatesViewModel,
+    viewModels: PortfolioViewModels,
     onProductClick: (String) -> Unit,
 ) {
-    val appsState by appsViewModel.uiState.collectAsState()
-    val pluginsState by pluginsViewModel.uiState.collectAsState()
-    val cliToolsState by cliToolsViewModel.uiState.collectAsState()
-    val templatesState by templatesViewModel.uiState.collectAsState()
+    val appsState by viewModels.apps.uiState.collectAsState()
+    val pluginsState by viewModels.plugins.uiState.collectAsState()
+    val cliToolsState by viewModels.cliTools.uiState.collectAsState()
+    val templatesState by viewModels.templates.uiState.collectAsState()
     val uriHandler = LocalUriHandler.current
 
-    val howOldAmI =
-        appsState.apps.find { it.nameRes == portfolio.composeapp.generated.resources.Res.string.app_name_howoldami }
-    val html2pdf = cliToolsState.cliTools.find { it.nameFallback == "@yuyuyuyuyu-dev/html2pdf" }
-    val notPullingCalc =
-        appsState.apps.find { it.nameRes == portfolio.composeapp.generated.resources.Res.string.app_name_notpullingcalc }
-    val inputSourceHandler = appsState.apps.find { it.nameFallback == "Input Source Handler" }
-    val composePwa = pluginsState.plugins.find { it.nameFallback == "ComposePWA" }
-    val businessCard = templatesState.templates.find { it.nameFallback == "business-card-template" }
+    val featuredItems =
+        TodayFeaturedItems(
+            howOldAmI = appsState.apps.find { it.nameRes == Res.string.app_name_howoldami },
+            html2pdf = cliToolsState.cliTools.find { it.nameFallback == "@yuyuyuyuyu-dev/html2pdf" },
+            notPullingCalc = appsState.apps.find { it.nameRes == Res.string.app_name_notpullingcalc },
+            inputSourceHandler = appsState.apps.find { it.nameFallback == "Input Source Handler" },
+            composePwa = pluginsState.plugins.find { it.nameFallback == "ComposePWA" },
+            businessCard = templatesState.templates.find { it.nameFallback == "business-card-template" },
+        )
 
     TodayScreenContent(
-        howOldAmI = howOldAmI,
-        html2pdf = html2pdf,
-        notPullingCalc = notPullingCalc,
-        inputSourceHandler = inputSourceHandler,
-        composePwa = composePwa,
-        businessCard = businessCard,
+        featuredItems = featuredItems,
         onProductClick = onProductClick,
         onLinkClick = { url -> uriHandler.openUri(url) },
     )
@@ -101,12 +93,7 @@ fun TodayScreen(
 
 @Composable
 fun TodayScreenContent(
-    howOldAmI: App?,
-    html2pdf: PortfolioItem?,
-    notPullingCalc: App?,
-    inputSourceHandler: App?,
-    composePwa: PortfolioItem?,
-    businessCard: PortfolioItem?,
+    featuredItems: TodayFeaturedItems,
     onProductClick: (String) -> Unit,
     onLinkClick: (String) -> Unit,
 ) {
@@ -129,67 +116,77 @@ fun TodayScreenContent(
             DeveloperPhilosophyCard()
         }
 
-        if (howOldAmI != null) {
-            item {
-                AppOfTheDayCard(
-                    app = howOldAmI,
-                    onClick = { onProductClick(howOldAmI.repositoryUrl) },
-                )
-            }
-        }
-
-        if (html2pdf != null) {
-            item {
-                ToolOfTheDayCard(
-                    product = html2pdf,
-                    title = stringResource(Res.string.ui_ultimate_laziness),
-                    onClick = { onProductClick(html2pdf.repositoryUrl) },
-                )
-            }
-        }
-
-        if (notPullingCalc != null) {
-            item {
-                AppOfTheDayCard(
-                    app = notPullingCalc,
-                    onClick = { onProductClick(notPullingCalc.repositoryUrl) },
-                )
-            }
-        }
-
-        if (composePwa != null) {
-            item {
-                ToolOfTheDayCard(
-                    product = composePwa,
-                    title = stringResource(Res.string.ui_dev_companion),
-                    onClick = { onProductClick(composePwa.repositoryUrl) },
-                )
-            }
-        }
-
-        if (businessCard != null) {
-            item {
-                ToolOfTheDayCard(
-                    product = businessCard,
-                    title = stringResource(Res.string.ui_familiar_tools),
-                    onClick = { onProductClick(businessCard.repositoryUrl) },
-                )
-            }
-        }
-
-        if (inputSourceHandler != null) {
-            item {
-                ToolOfTheDayCard(
-                    product = inputSourceHandler,
-                    title = stringResource(Res.string.ui_mac_utility),
-                    onClick = { onProductClick(inputSourceHandler.repositoryUrl) },
-                )
-            }
-        }
+        featuredProductItems(
+            featuredItems = featuredItems,
+            onProductClick = onProductClick,
+        )
 
         item {
             DeveloperProfileCard(
                 onLinkClick = onLinkClick,
+            )
+        }
+    }
+}
+
+private fun LazyListScope.featuredProductItems(
+    featuredItems: TodayFeaturedItems,
+    onProductClick: (String) -> Unit,
+) {
+    featuredItems.howOldAmI?.let { app ->
+        item {
+            AppOfTheDayCard(
+                app = app,
+                onClick = { onProductClick(app.repositoryUrl) },
+            )
+        }
+    }
+
+    featuredItems.html2pdf?.let { product ->
+        item {
+            ToolOfTheDayCard(
+                product = product,
+                title = stringResource(Res.string.ui_ultimate_laziness),
+                onClick = { onProductClick(product.repositoryUrl) },
+            )
+        }
+    }
+
+    featuredItems.notPullingCalc?.let { app ->
+        item {
+            AppOfTheDayCard(
+                app = app,
+                onClick = { onProductClick(app.repositoryUrl) },
+            )
+        }
+    }
+
+    featuredItems.composePwa?.let { product ->
+        item {
+            ToolOfTheDayCard(
+                product = product,
+                title = stringResource(Res.string.ui_dev_companion),
+                onClick = { onProductClick(product.repositoryUrl) },
+            )
+        }
+    }
+
+    featuredItems.businessCard?.let { product ->
+        item {
+            ToolOfTheDayCard(
+                product = product,
+                title = stringResource(Res.string.ui_familiar_tools),
+                onClick = { onProductClick(product.repositoryUrl) },
+            )
+        }
+    }
+
+    featuredItems.inputSourceHandler?.let { product ->
+        item {
+            ToolOfTheDayCard(
+                product = product,
+                title = stringResource(Res.string.ui_mac_utility),
+                onClick = { onProductClick(product.repositoryUrl) },
             )
         }
     }
@@ -236,67 +233,65 @@ fun DeveloperProfileCard(
                 )
             }
 
-            Column(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ProfileLinks(
+                onLinkClick = onLinkClick,
                 modifier = Modifier.padding(top = 8.dp),
-            ) {
-                OutlinedButton(
-                    onClick = { onLinkClick("https://x.com/yuyuyuyuyu_dev") },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onTertiaryContainer),
-                ) {
-                    Icon(
-                        Icons.Default.Person,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text("X")
-                }
-
-                OutlinedButton(
-                    onClick = { onLinkClick("https://github.com/yuyuyuyuyu-dev") },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onTertiaryContainer),
-                ) {
-                    Icon(
-                        Icons.Default.Code,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text("GitHub")
-                }
-
-                OutlinedButton(
-                    onClick = { onLinkClick("https://youtrust.jp/users/bb7902cca964b92558d0116a5f44f362") },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onTertiaryContainer),
-                ) {
-                    Icon(
-                        Icons.Default.Person,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text("YOUTRUST")
-                }
-
-                OutlinedButton(
-                    onClick = { onLinkClick("mailto:yu.kobayashi@yuyuyuyuyu.dev") },
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onTertiaryContainer),
-                ) {
-                    Icon(
-                        Icons.Default.Email,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(Res.string.ui_email_link))
-                }
-            }
+            )
         }
+    }
+}
+
+@Composable
+private fun ProfileLinks(
+    onLinkClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier,
+    ) {
+        ProfileLinkButton(
+            icon = Icons.Default.Person,
+            label = "X",
+            onClick = { onLinkClick("https://x.com/yuyuyuyuyu_dev") },
+        )
+        ProfileLinkButton(
+            icon = Icons.Default.Code,
+            label = "GitHub",
+            onClick = { onLinkClick("https://github.com/yuyuyuyuyu-dev") },
+        )
+        ProfileLinkButton(
+            icon = Icons.Default.Person,
+            label = "YOUTRUST",
+            onClick = { onLinkClick("https://youtrust.jp/users/bb7902cca964b92558d0116a5f44f362") },
+        )
+        ProfileLinkButton(
+            icon = Icons.Default.Email,
+            label = stringResource(Res.string.ui_email_link),
+            onClick = { onLinkClick("mailto:yu.kobayashi@yuyuyuyuyu.dev") },
+        )
+    }
+}
+
+@Composable
+private fun ProfileLinkButton(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.onTertiaryContainer),
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(label)
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/today/TodayScreenContentTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/today/TodayScreenContentTest.kt
@@ -27,12 +27,7 @@ class TodayScreenContentTest {
 
             setContent {
                 TodayScreenContent(
-                    howOldAmI = mockApp,
-                    html2pdf = null,
-                    notPullingCalc = null,
-                    inputSourceHandler = null,
-                    composePwa = null,
-                    businessCard = null,
+                    featuredItems = TodayFeaturedItems(howOldAmI = mockApp),
                     onProductClick = {},
                     onLinkClick = {},
                 )

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,121 +1,25 @@
-build:
-  maxIssues: 0
-
-style:
-  active: true
-  UnusedPrivateClass:
-    active: true
-  UnusedPrivateMember:
-    active: true
-    allowedNames: '.*Preview' # Ignore Compose previews
-  UnusedPrivateProperty:
-    active: true
-  # Disable all other noisy style rules for now to allow build to pass
-  CollapsibleIfStatements:
-    active: false
-  DestructuringDeclarationWithTooManyEntries:
-    active: false
-  EqualsOnSignatureLine:
-    active: false
-  ExplicitItLambdaParameter:
-    active: false
-  ExpressionBodySyntax:
-    active: false
-  ForbiddenComment:
-    active: false
-  LoopWithTooManyJumpStatements:
-    active: false
-  MagicNumber:
-    active: false
-  MandatoryBracesLoops:
-    active: false
-  MaxLineLength:
-    active: false
-  MayBeConst:
-    active: false
-  ModifierOrder:
-    active: false
-  NestedClassesVisibility:
-    active: false
-  NewLineAtEndOfFile:
-    active: false
-  NoTabs:
-    active: false
-  OptionalAbstractKeyword:
-    active: false
-  OptionalUnit:
-    active: false
-  ProtectedMemberInFinalClass:
-    active: false
-  RedundantExplicitType:
-    active: false
-  RedundantVisibilityModifierRule:
-    active: false
-  ReturnCount:
-    active: false
-  SafeCast:
-    active: false
-  SerialVersionUIDInSerializableClass:
-    active: false
-  SpacingBetweenPackageAndImports:
-    active: false
-  ThrowsCount:
-    active: false
-  TrailingWhitespace:
-    active: false
-  UnderscoresInNumericLiterals:
-    active: false
-  UnnecessaryAbstractClass:
-    active: false
-  UnnecessaryAnnotationUseSiteTarget:
-    active: false
-  UnnecessaryApply:
-    active: false
-  UnnecessaryFilter:
-    active: false
-  UnnecessaryInheritance:
-    active: false
-  UnnecessaryLet:
-    active: false
-  UnnecessaryParentheses:
-    active: false
-  UntilInsteadOfRangeTo:
-    active: false
-  UnusedImports:
-    active: false
-  UseAnyOrNoneInsteadOfFind:
-    active: false
-  UseArrayLiteralsInAnnotations:
-    active: false
-  UseCheckNotNull:
-    active: false
-  UseCheckOrError:
-    active: false
-  UseDataClass:
-    active: false
-  UseEmptyCounterpart:
-    active: false
-  UseIfInsteadOfWhen:
-    active: false
-  UseIsNullOrEmpty:
-    active: false
-  UseOrEmpty:
-    active: false
-  UseRequire:
-    active: false
-  UseRequireNotNull:
-    active: false
-  WildcardImport:
-    active: false
+# Deviations from the default config (buildUponDefaultConfig = true).
+# Keep this file limited to:
+#   - the official adjustments for Compose: https://detekt.dev/docs/introduction/compose/
+#   - disabling rules that overlap with ktlint, which owns formatting
 
 complexity:
-  active: false
+  LongParameterList:
+    ignoreDefaultParameters: true
+  TooManyFunctions:
+    ignoreAnnotatedFunctions: ['Preview']
 
 naming:
-  active: false
+  FunctionNaming:
+    ignoreAnnotated: ['Composable']
+  TopLevelPropertyNaming:
+    constantPattern: '[A-Z][A-Za-z0-9]*'
 
-empty-blocks:
-  active: true
-
-potential-bugs:
-  active: true
+style:
+  MagicNumber:
+    ignorePropertyDeclaration: true
+  MaxLineLength:
+    # Line length is enforced by ktlint (140 in the ktlint_official code style).
+    active: false
+  UnusedPrivateMember:
+    ignoreAnnotated: ['Preview']


### PR DESCRIPTION
## Summary

This PR strips the ktlint and detekt configuration down to the bare minimum that the tools themselves ask a user to decide, and lets the bundled defaults govern everything else.

### What the remaining config is for

Neither tool can detect on its own that this is a Compose project, so that is essentially the only thing left declared:

- **`.editorconfig`** — two properties that are ktlint's documented accommodations for Compose: `ktlint_function_naming_ignore_when_annotated_with = Composable` and `ktlint_property_naming_constant_naming = pascal_case`. The dead `[**/main.kt]` filename override was removed (the entry points are named `Main.kt`, which already satisfies the filename rule).
- **`detekt.yml`** — shrunk from ~50 hand-picked rule opt-outs to just the [official adjustments for Compose](https://detekt.dev/docs/introduction/compose/) plus one ktlint-overlap exception (`MaxLineLength` off, since ktlint already enforces 140 via `ktlint_official`). The stale `baseline` reference (the file never existed) and the redundant `allRules = false` are gone too.

### Found along the way: the detekt CI job analyzed zero files

The plain `detekt` task only looks at the default JVM source locations (`src/main/kotlin` etc.), which do not exist in this KMP layout, so `./gradlew detekt` in CI has been completing without analyzing a single file. The task is now pointed at `src`, so it covers all source sets. ([detekt's KMP docs](https://detekt.dev/docs/gettingstarted/type-resolution/) only offer per-target tasks, several of which are experimental and require type resolution, so configuring the plain task is the simplest way to keep `./gradlew detekt` meaningful.)

### Code changes required by the restored default rules

Re-enabling the default rules surfaced 25 real findings, fixed by refactoring rather than suppression. UI behavior is unchanged:

- The five view models that were threaded through every portfolio screen are grouped into an injected `PortfolioViewModels` parameter object, and the Today screen's hand-picked items into `TodayFeaturedItems` (**LongParameterList**).
- The oversized screen composables (`DetailScreen` was 139 lines) are split into focused section composables (**LongMethod**).
- The drawing constants in `PortfolioItemIcon` got names, and the pill shapes use a named `percent` argument (**MagicNumber**).

## Verification

All four CI jobs were run locally on the final tree and pass:

- `./gradlew ktlintCheck`
- `./gradlew detekt` (now actually analyzing 70 files)
- `./gradlew wasmJsTest`
- `./gradlew :composeApp:exportLibraryDefinitions ... && ./gradlew :composeApp:wasmJsBrowserDistribution`

🤖 Generated with [Claude Code](https://claude.com/claude-code)