### PR TITLE
test: extract and unit-test search filter logic

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/ResolvedPortfolioItem.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/ResolvedPortfolioItem.kt
@@ -1,0 +1,15 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio.search
+
+import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
+
+/**
+ * A [PortfolioItem] paired with its display strings already resolved from
+ * string resources. Resolving requires a @Composable context, so the caller
+ * does it; [filterResolvedItems] stays pure to keep the search logic
+ * unit-testable without the Compose runtime.
+ */
+data class ResolvedPortfolioItem(
+    val item: PortfolioItem,
+    val name: String,
+    val description: String,
+)

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchFilter.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchFilter.kt
@@ -1,0 +1,33 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio.search
+
+import dev.yuyuyuyuyu.portfolio.data.models.Platform
+import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
+import dev.yuyuyuyuyu.portfolio.data.models.ProductCategory
+
+/**
+ * Returns the items matching a free-text [query] (compared against name and
+ * description, case-insensitively) and the optional [category] / [platform]
+ * facets. A null facet means "no constraint" and a blank query matches
+ * everything; all conditions are combined with AND. The input order is
+ * preserved.
+ */
+fun filterResolvedItems(
+    items: List<ResolvedPortfolioItem>,
+    query: String,
+    category: ProductCategory?,
+    platform: Platform?,
+): List<PortfolioItem> =
+    items
+        .filter { resolved ->
+            val matchesQuery =
+                if (query.isBlank()) {
+                    true
+                } else {
+                    resolved.name.contains(query, ignoreCase = true) ||
+                        resolved.description.contains(query, ignoreCase = true)
+                }
+            val matchesCategory = category == null || resolved.item.category == category
+            val matchesPlatform = platform == null || resolved.item.platforms.contains(platform)
+
+            matchesQuery && matchesCategory && matchesPlatform
+        }.map { it.item }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchScreen.kt
@@ -86,32 +86,18 @@ fun SearchScreenContent(
     var selectedCategory by remember { mutableStateOf<ProductCategory?>(null) }
     var selectedPlatform by remember { mutableStateOf<Platform?>(null) }
 
-    // Resolve strings for filtering
-    val itemWithStrings =
+    // Resolve strings here (requires a @Composable context), then delegate the
+    // actual filtering to the pure filterResolvedItems so it stays testable.
+    val resolvedItems =
         allItems.map { item ->
-            val resolvedName = item.displayName
-            val resolvedDesc = item.displayDescription
-            Triple<PortfolioItem, String, String>(item, resolvedName, resolvedDesc)
+            ResolvedPortfolioItem(
+                item = item,
+                name = item.displayName,
+                description = item.displayDescription,
+            )
         }
 
-    // Filter logic
-    val filteredItems =
-        itemWithStrings
-            .filter { triple ->
-                val item = triple.first
-                val name = triple.second
-                val description = triple.third
-                val matchesQuery =
-                    if (searchQuery.isBlank()) {
-                        true
-                    } else {
-                        name.contains(searchQuery, ignoreCase = true) || description.contains(searchQuery, ignoreCase = true)
-                    }
-                val matchesCategory = if (selectedCategory == null) true else item.category == selectedCategory
-                val matchesPlatform = if (selectedPlatform == null) true else item.platforms.contains(selectedPlatform)
-
-                matchesQuery && matchesCategory && matchesPlatform
-            }.map { it.first }
+    val filteredItems = filterResolvedItems(resolvedItems, searchQuery, selectedCategory, selectedPlatform)
 
     Column(modifier = Modifier.fillMaxSize()) {
         SearchQueryField(

--- a/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchFilterTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchFilterTest.kt
@@ -1,0 +1,130 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio.search
+
+import dev.yuyuyuyuyu.portfolio.data.models.App
+import dev.yuyuyuyuyu.portfolio.data.models.Platform
+import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
+import dev.yuyuyuyuyu.portfolio.data.models.ProductCategory
+import portfolio.composeapp.generated.resources.Res
+import portfolio.composeapp.generated.resources.app_name
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SearchFilterTest {
+    @Test
+    fun blankQuery_withoutFacets_returnsEveryItem() {
+        val items = listOf(resolved("Alpha"), resolved("Beta"))
+
+        val result = filterResolvedItems(items, query = "", category = null, platform = null)
+
+        assertEquals(listOf("Alpha", "Beta"), result.names())
+    }
+
+    @Test
+    fun query_matchesNameCaseInsensitively() {
+        val items = listOf(resolved("Alpha"), resolved("Beta"))
+
+        val result = filterResolvedItems(items, query = "alp", category = null, platform = null)
+
+        assertEquals(listOf("Alpha"), result.names())
+    }
+
+    @Test
+    fun query_matchesDescription() {
+        val items =
+            listOf(
+                resolved("Alpha", description = "a fast CLI tool"),
+                resolved("Beta", description = "a slow GUI app"),
+            )
+
+        val result = filterResolvedItems(items, query = "fast", category = null, platform = null)
+
+        assertEquals(listOf("Alpha"), result.names())
+    }
+
+    @Test
+    fun query_withNoMatch_returnsEmpty() {
+        val items = listOf(resolved("Alpha"), resolved("Beta"))
+
+        val result = filterResolvedItems(items, query = "zzz", category = null, platform = null)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun categoryFacet_keepsOnlyMatchingCategory() {
+        val items =
+            listOf(
+                resolved("Alpha", category = ProductCategory.App),
+                resolved("Beta", category = ProductCategory.Library),
+            )
+
+        val result = filterResolvedItems(items, query = "", category = ProductCategory.Library, platform = null)
+
+        assertEquals(listOf("Beta"), result.names())
+    }
+
+    @Test
+    fun platformFacet_keepsOnlyItemsSupportingThatPlatform() {
+        val items =
+            listOf(
+                resolved("Alpha", platforms = setOf(Platform.Web)),
+                resolved("Beta", platforms = setOf(Platform.Android)),
+            )
+
+        val result = filterResolvedItems(items, query = "", category = null, platform = Platform.Web)
+
+        assertEquals(listOf("Alpha"), result.names())
+    }
+
+    @Test
+    fun queryAndFacets_combineWithAndSemantics() {
+        val items =
+            listOf(
+                resolved("Web App", category = ProductCategory.App, platforms = setOf(Platform.Web)),
+                resolved("Web Lib", category = ProductCategory.Library, platforms = setOf(Platform.Web)),
+                resolved("Android App", category = ProductCategory.App, platforms = setOf(Platform.Android)),
+            )
+
+        val result =
+            filterResolvedItems(
+                items,
+                query = "web",
+                category = ProductCategory.App,
+                platform = Platform.Web,
+            )
+
+        assertEquals(listOf("Web App"), result.names())
+    }
+
+    @Test
+    fun result_preservesInputOrder() {
+        val items = listOf(resolved("Gamma"), resolved("Alpha"), resolved("Beta"))
+
+        val result = filterResolvedItems(items, query = "", category = null, platform = null)
+
+        assertEquals(listOf("Gamma", "Alpha", "Beta"), result.names())
+    }
+
+    private fun List<PortfolioItem>.names(): List<String?> = map { it.nameFallback }
+
+    private fun resolved(
+        name: String,
+        description: String = "",
+        category: ProductCategory = ProductCategory.App,
+        platforms: Set<Platform> = emptySet(),
+    ): ResolvedPortfolioItem =
+        ResolvedPortfolioItem(
+            item =
+                App(
+                    nameFallback = name,
+                    descriptionRes = Res.string.app_name,
+                    techStack = emptySet(),
+                    repositoryUrl = "https://github.com",
+                    platforms = platforms,
+                    category = category,
+                ),
+            name = name,
+            description = description,
+        )
+}


### PR DESCRIPTION
## Summary

The search filter logic lived inside the `SearchScreenContent` composable, entangled with remembered UI state, so it could only be exercised through the Compose runtime. This branch extracts it into a pure, unit-testable function and adds focused tests for it.

## Changes

- **Refactor** — extract filtering into a pure `filterResolvedItems(items, query, category, platform)` function, backed by a small `ResolvedPortfolioItem` holder. The composable now only resolves the display strings (which needs a `@Composable` context) and delegates. **Behavior is unchanged.**
- **Tests** — add `SearchFilterTest` covering:
  - query matching against name and description (case-insensitive)
  - category and platform facets
  - AND combination of query + both facets
  - the empty-result case
  - input-order preservation

## Verification

- `./gradlew :composeApp:ktlintCheck` ✅
- `./gradlew :composeApp:detekt` ✅
- `./gradlew :composeApp:wasmJsTest` ✅ — all 8 new tests run and pass on the production wasmJs target (ChromeHeadless)

## Scope

Intentionally narrow: only the search filter logic. UI-wiring tests for the full `SearchScreen` and logic in other screens are out of scope and left for separate branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)