### PR TITLE
test: extract and unit-test catalog grouping logic

### DIFF
--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogScreen.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogScreen.kt
@@ -16,20 +16,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import dev.yuyuyuyuyu.portfolio.data.models.Platform
 import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
-import dev.yuyuyuyuyu.portfolio.data.models.ProductCategory
 import dev.yuyuyuyuyu.portfolio.ui.components.listItems.PortfolioItemTile
 import dev.yuyuyuyuyu.portfolio.ui.portfolio.PortfolioViewModels
 import org.jetbrains.compose.resources.stringResource
-import portfolio.composeapp.generated.resources.Res
-import portfolio.composeapp.generated.resources.ui_cli_tools
-import portfolio.composeapp.generated.resources.ui_libraries
-import portfolio.composeapp.generated.resources.ui_mac_apps
-import portfolio.composeapp.generated.resources.ui_mobile_other_apps
-import portfolio.composeapp.generated.resources.ui_plugins
-import portfolio.composeapp.generated.resources.ui_templates
-import portfolio.composeapp.generated.resources.ui_web_apps
 
 @Composable
 fun CatalogScreen(
@@ -55,28 +45,7 @@ fun CatalogScreenContent(
     allProducts: List<PortfolioItem>,
     onProductClick: (String) -> Unit,
 ) {
-    // Group apps
-    val macApps = allApps.filter { Platform.MacOS in it.platforms }
-    val webApps = allApps.filter { Platform.Web in it.platforms }
-    val androidIosApps = allApps.filter { Platform.Android in it.platforms || Platform.Ios in it.platforms }
-    val otherApps = allApps - macApps.toSet() - webApps.toSet() - androidIosApps.toSet()
-
-    // SSoT: Group by actual data properties
-    val cliTools = allProducts.filter { it.category == ProductCategory.CliTool }.sortedBy { it.nameFallback }
-    val plugins = allProducts.filter { it.category == ProductCategory.Plugin }.sortedBy { it.nameFallback }
-    val libraries = allProducts.filter { it.category == ProductCategory.Library }.sortedBy { it.nameFallback }
-    val templates = allProducts.filter { it.category == ProductCategory.Template }.sortedBy { it.nameFallback }
-
-    val sections =
-        listOf(
-            Res.string.ui_web_apps to webApps,
-            Res.string.ui_plugins to plugins,
-            Res.string.ui_libraries to libraries,
-            Res.string.ui_cli_tools to cliTools,
-            Res.string.ui_templates to templates,
-            Res.string.ui_mac_apps to macApps,
-            Res.string.ui_mobile_other_apps to (androidIosApps + otherApps),
-        )
+    val sections = catalogSections(allApps, allProducts)
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -84,14 +53,12 @@ fun CatalogScreenContent(
         verticalArrangement = Arrangement.spacedBy(32.dp),
     ) {
         sections.forEach { (titleRes, sectionItems) ->
-            if (sectionItems.isNotEmpty()) {
-                item {
-                    CatalogSection(
-                        title = stringResource(titleRes),
-                        items = sectionItems,
-                        onProductClick = onProductClick,
-                    )
-                }
+            item {
+                CatalogSection(
+                    title = stringResource(titleRes),
+                    items = sectionItems,
+                    onProductClick = onProductClick,
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogSections.kt
+++ b/composeApp/src/commonMain/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogSections.kt
@@ -1,0 +1,49 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio.catalog
+
+import dev.yuyuyuyuyu.portfolio.data.models.Platform
+import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
+import dev.yuyuyuyuyu.portfolio.data.models.ProductCategory
+import org.jetbrains.compose.resources.StringResource
+import portfolio.composeapp.generated.resources.Res
+import portfolio.composeapp.generated.resources.ui_cli_tools
+import portfolio.composeapp.generated.resources.ui_libraries
+import portfolio.composeapp.generated.resources.ui_mac_apps
+import portfolio.composeapp.generated.resources.ui_mobile_other_apps
+import portfolio.composeapp.generated.resources.ui_plugins
+import portfolio.composeapp.generated.resources.ui_templates
+import portfolio.composeapp.generated.resources.ui_web_apps
+
+/**
+ * Groups the catalog data into the ordered, titled sections shown on the
+ * catalog screen.
+ *
+ * Apps in [allApps] are bucketed by platform; an app supporting several
+ * platforms appears in every matching bucket, and any app matching none of the
+ * mac / web / Android-iOS buckets falls into "mobile & other". Products in
+ * [allProducts] are split by category and sorted by name. Empty sections are
+ * dropped. Kept pure so it can be unit-tested without the Compose runtime.
+ */
+fun catalogSections(
+    allApps: List<PortfolioItem>,
+    allProducts: List<PortfolioItem>,
+): List<Pair<StringResource, List<PortfolioItem>>> {
+    val macApps = allApps.filter { Platform.MacOS in it.platforms }
+    val webApps = allApps.filter { Platform.Web in it.platforms }
+    val androidIosApps = allApps.filter { Platform.Android in it.platforms || Platform.Ios in it.platforms }
+    val otherApps = allApps - macApps.toSet() - webApps.toSet() - androidIosApps.toSet()
+
+    val cliTools = allProducts.filter { it.category == ProductCategory.CliTool }.sortedBy { it.nameFallback }
+    val plugins = allProducts.filter { it.category == ProductCategory.Plugin }.sortedBy { it.nameFallback }
+    val libraries = allProducts.filter { it.category == ProductCategory.Library }.sortedBy { it.nameFallback }
+    val templates = allProducts.filter { it.category == ProductCategory.Template }.sortedBy { it.nameFallback }
+
+    return listOf(
+        Res.string.ui_web_apps to webApps,
+        Res.string.ui_plugins to plugins,
+        Res.string.ui_libraries to libraries,
+        Res.string.ui_cli_tools to cliTools,
+        Res.string.ui_templates to templates,
+        Res.string.ui_mac_apps to macApps,
+        Res.string.ui_mobile_other_apps to (androidIosApps + otherApps),
+    ).filter { (_, items) -> items.isNotEmpty() }
+}

--- a/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogSectionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/catalog/CatalogSectionsTest.kt
@@ -1,0 +1,169 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio.catalog
+
+import dev.yuyuyuyuyu.portfolio.data.models.App
+import dev.yuyuyuyuyu.portfolio.data.models.Platform
+import dev.yuyuyuyuyu.portfolio.data.models.PortfolioItem
+import dev.yuyuyuyuyu.portfolio.data.models.Product
+import dev.yuyuyuyuyu.portfolio.data.models.ProductCategory
+import org.jetbrains.compose.resources.StringResource
+import portfolio.composeapp.generated.resources.Res
+import portfolio.composeapp.generated.resources.app_name
+import portfolio.composeapp.generated.resources.ui_cli_tools
+import portfolio.composeapp.generated.resources.ui_libraries
+import portfolio.composeapp.generated.resources.ui_mac_apps
+import portfolio.composeapp.generated.resources.ui_mobile_other_apps
+import portfolio.composeapp.generated.resources.ui_plugins
+import portfolio.composeapp.generated.resources.ui_templates
+import portfolio.composeapp.generated.resources.ui_web_apps
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CatalogSectionsTest {
+    @Test
+    fun app_isBucketedByItsPlatform() {
+        val sections =
+            catalogSections(
+                allApps = listOf(app("Web App", Platform.Web), app("Mac App", Platform.MacOS)),
+                allProducts = emptyList(),
+            )
+
+        assertEquals(listOf("Web App"), sections.section(Res.string.ui_web_apps))
+        assertEquals(listOf("Mac App"), sections.section(Res.string.ui_mac_apps))
+    }
+
+    @Test
+    fun multiPlatformApp_appearsInEveryMatchingBucket() {
+        val sections =
+            catalogSections(
+                allApps = listOf(app("Cross", Platform.MacOS, Platform.Web)),
+                allProducts = emptyList(),
+            )
+
+        assertEquals(listOf("Cross"), sections.section(Res.string.ui_web_apps))
+        assertEquals(listOf("Cross"), sections.section(Res.string.ui_mac_apps))
+    }
+
+    @Test
+    fun androidOrIosApp_goesIntoMobileAndOther() {
+        val sections =
+            catalogSections(
+                allApps = listOf(app("Mobile", Platform.Android)),
+                allProducts = emptyList(),
+            )
+
+        assertEquals(listOf("Mobile"), sections.section(Res.string.ui_mobile_other_apps))
+    }
+
+    @Test
+    fun appMatchingNoKnownBucket_fallsIntoMobileAndOther() {
+        val sections =
+            catalogSections(
+                allApps = listOf(app("Win", Platform.Windows)),
+                allProducts = emptyList(),
+            )
+
+        assertEquals(listOf("Win"), sections.section(Res.string.ui_mobile_other_apps))
+    }
+
+    @Test
+    fun bucketedApp_isNotAlsoDumpedIntoMobileAndOther() {
+        val sections =
+            catalogSections(
+                allApps = listOf(app("Web", Platform.Web)),
+                allProducts = emptyList(),
+            )
+
+        assertTrue(sections.section(Res.string.ui_mobile_other_apps).isEmpty())
+    }
+
+    @Test
+    fun products_areSplitByCategoryAndSortedByName() {
+        val sections =
+            catalogSections(
+                allApps = emptyList(),
+                allProducts =
+                    listOf(
+                        product("zeta-lib", ProductCategory.Library),
+                        product("alpha-lib", ProductCategory.Library),
+                        product("my-plugin", ProductCategory.Plugin),
+                    ),
+            )
+
+        assertEquals(listOf("alpha-lib", "zeta-lib"), sections.section(Res.string.ui_libraries))
+        assertEquals(listOf("my-plugin"), sections.section(Res.string.ui_plugins))
+    }
+
+    @Test
+    fun emptySections_areDropped() {
+        val sections =
+            catalogSections(
+                allApps = listOf(app("Web", Platform.Web)),
+                allProducts = emptyList(),
+            )
+
+        assertEquals(listOf(Res.string.ui_web_apps), sections.map { it.first })
+    }
+
+    @Test
+    fun sections_keepTheirDefinedOrder() {
+        val sections =
+            catalogSections(
+                allApps =
+                    listOf(
+                        app("WebOnly", Platform.Web),
+                        app("MacOnly", Platform.MacOS),
+                        app("AndroidOnly", Platform.Android),
+                    ),
+                allProducts =
+                    listOf(
+                        product("plug", ProductCategory.Plugin),
+                        product("lib", ProductCategory.Library),
+                        product("cli", ProductCategory.CliTool),
+                        product("tmpl", ProductCategory.Template),
+                    ),
+            )
+
+        assertEquals(
+            listOf(
+                Res.string.ui_web_apps,
+                Res.string.ui_plugins,
+                Res.string.ui_libraries,
+                Res.string.ui_cli_tools,
+                Res.string.ui_templates,
+                Res.string.ui_mac_apps,
+                Res.string.ui_mobile_other_apps,
+            ),
+            sections.map { it.first },
+        )
+    }
+
+    private fun List<Pair<StringResource, List<PortfolioItem>>>.section(titleRes: StringResource): List<String?> =
+        firstOrNull { it.first == titleRes }?.second?.map { it.nameFallback } ?: emptyList()
+
+    private fun app(
+        name: String,
+        vararg platforms: Platform,
+    ): App =
+        App(
+            nameFallback = name,
+            descriptionRes = Res.string.app_name,
+            techStack = emptySet(),
+            repositoryUrl = "https://github.com",
+            platforms = platforms.toSet(),
+            category = ProductCategory.App,
+        )
+
+    private fun product(
+        name: String,
+        category: ProductCategory,
+    ): Product =
+        Product(
+            nameFallback = name,
+            descriptionRes = Res.string.app_name,
+            techStack = emptySet(),
+            repositoryUrl = "https://github.com",
+            platforms = emptySet(),
+            category = category,
+        )
+}


### PR DESCRIPTION
## Summary

Same pattern as #42, applied to the catalog screen. The platform/category grouping logic lived inside the `CatalogScreenContent` composable, so it could only be exercised through the Compose runtime. This branch extracts it into a pure, unit-testable function and adds focused tests.

## Changes

- **Refactor** — extract the grouping into a pure `catalogSections(allApps, allProducts)` returning the ordered, non-empty `StringResource`-titled sections. The composable now just renders them; empty-section dropping moves from the render loop into the function. **Behavior is unchanged.**
- **Tests** — add `CatalogSectionsTest` covering:
  - apps bucketed by platform, with multi-platform apps appearing in every matching bucket
  - the "mobile & other" fallback for Android/iOS and otherwise-unbucketed apps
  - a bucketed app not being duplicated into "mobile & other"
  - products split by category and sorted by name
  - empty sections dropped
  - section ordering

## Verification

- `./gradlew :composeApp:ktlintCheck` ✅
- `./gradlew :composeApp:detekt` ✅
- `./gradlew :composeApp:wasmJsTest` ✅ — all 8 new tests run and pass on the production wasmJs target (ChromeHeadless)

## Scope

Intentionally narrow: only the catalog grouping logic, matching the branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)