### PR TITLE
test: add full-stack wiring test for SearchScreen

### DIFF
--- a/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchScreenWiringTest.kt
+++ b/composeApp/src/commonTest/kotlin/dev/yuyuyuyuyu/portfolio/ui/portfolio/search/SearchScreenWiringTest.kt
@@ -1,0 +1,69 @@
+package dev.yuyuyuyuyu.portfolio.ui.portfolio.search
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import dev.yuyuyuyuyu.portfolio.data.repositories.AppsRepository
+import dev.yuyuyuyuyu.portfolio.data.repositories.CliToolsRepository
+import dev.yuyuyuyuyu.portfolio.data.repositories.LibrariesRepository
+import dev.yuyuyuyuyu.portfolio.data.repositories.PluginsRepository
+import dev.yuyuyuyuyu.portfolio.data.repositories.TemplatesRepository
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.PortfolioViewModels
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.apps.AppsViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.cliTools.CliToolsViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.libraries.LibrariesViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.plugins.PluginsViewModelImpl
+import dev.yuyuyuyuyu.portfolio.ui.portfolio.templates.TemplatesViewModelImpl
+import kotlin.test.Test
+
+/**
+ * Exercises the full SearchScreen wiring with no mocks: real repositories feed
+ * real view models, which the screen merges and renders. Each test types a
+ * substring of a known item's name to narrow the results to that single item,
+ * which sidesteps lazy-list virtualization and avoids colliding with the query
+ * text shown in the search field (the typed substring never equals the
+ * asserted full name).
+ */
+class SearchScreenWiringTest {
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun searchScreen_surfacesAnAppFromRealViewModels() =
+        runComposeUiTest {
+            val viewModels = realViewModels()
+
+            setContent {
+                SearchScreen(viewModels = viewModels, onProductClick = {})
+            }
+
+            onNode(hasSetTextAction()).performTextInput("PureMusic")
+
+            onNodeWithText("PureMusicPlayer").assertIsDisplayed()
+        }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun searchScreen_surfacesACliToolFromRealViewModels() =
+        runComposeUiTest {
+            val viewModels = realViewModels()
+
+            setContent {
+                SearchScreen(viewModels = viewModels, onProductClick = {})
+            }
+
+            onNode(hasSetTextAction()).performTextInput("html2pdf")
+
+            onNodeWithText("@yuyuyuyuyu-dev/html2pdf").assertIsDisplayed()
+        }
+
+    private fun realViewModels(): PortfolioViewModels =
+        PortfolioViewModels(
+            apps = AppsViewModelImpl(AppsRepository()),
+            libraries = LibrariesViewModelImpl(LibrariesRepository()),
+            plugins = PluginsViewModelImpl(PluginsRepository()),
+            cliTools = CliToolsViewModelImpl(CliToolsRepository()),
+            templates = TemplatesViewModelImpl(TemplatesRepository()),
+        )
+}


### PR DESCRIPTION
## Summary

Follow-up to #42 and #43. Those covered the extracted pure logic; this adds the complementary "thin, transitive" layer: a single full-stack UI test that drives `SearchScreen` through **real** view models and repositories (no mocks), confirming data actually flows from the repositories, through the view models, into the rendered screen.

## Approach

- Build a real `PortfolioViewModels` from real `*ViewModelImpl` + `*Repository` instances (all have trivial constructors, so no DI graph is needed).
- Render the top-level `SearchScreen` and type a **substring** of a known item's name into the search field. This:
  - narrows the results to a single item, sidestepping lazy-list virtualization, and
  - keeps the typed query different from the asserted full name, so `onNodeWithText` does not also match the text echoed in the search field.
- Two cases assert on items sourced from **different** view models (an app and a CLI tool), exercising the cross-view-model merge wiring.

## Verification

- `./gradlew :composeApp:ktlintCheck` ✅
- `./gradlew :composeApp:detekt` ✅
- `./gradlew :composeApp:wasmJsTest` ✅ — both new tests run and pass on the production wasmJs target (ChromeHeadless)

## Scope

Intentionally narrow: one wiring test for `SearchScreen` (the screen that merges all five view models). The catalog screen's wiring is analogous and left uncovered by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)