### PR TITLE
ci: support merge queue (add merge_group trigger)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What
Add the `merge_group` trigger to `ci-cd.yml` so the required checks (Build, ktlint, detekt, Run tests) also run on merge queue entries.

## Why
Prerequisite for switching `main` to a **merge queue**, which serializes merges and rebases+re-tests each PR against the latest `main` automatically — removing the wasted parallel CI caused by the "require up to date with main" rule. This repo is the **Merge Queue only** variant (manual merge; no auto-merge).

## Order matters
The `merge_group` trigger must be on `main` **before** the merge queue is enabled, or queued PRs never get their checks and stall. Please review & merge this PR first; then the merge queue will be enabled (add `merge_queue` rule + turn off the strict "up to date" requirement, which is incompatible with merge queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)