### PR TITLE
Introduce version-catalog-update-plugin with standard defaults

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,30 @@ jobs:
       - name: Static code analysis (detekt)
         run: ./gradlew detekt
 
+  version-catalog:
+    name: Check version catalog formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'jetbrains'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # Reformat the catalog in place and fail if anything changed, so the
+      # committed gradle/libs.versions.toml stays sorted and canonically
+      # formatted no matter who edits it by hand.
+      - name: Check version catalog formatting
+        run: |
+          ./gradlew versionCatalogFormat
+          git diff --exit-code gradle/libs.versions.toml
+
   test:
     name: Run tests
     runs-on: ubuntu-latest
@@ -101,7 +125,7 @@ jobs:
     # Deploy only after every check and the build have passed, and only for
     # pushes to main. Pull requests run the checks and the build for
     # verification only.
-    needs: [ ktlint, detekt, test, build ]
+    needs: [ ktlint, detekt, version-catalog, test, build ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,4 +10,8 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.detekt) apply false
+
+    // applied (not `apply false`) because it contributes the version catalog
+    // update tasks to this root project, where the catalog lives
+    alias(libs.plugins.versionCatalogUpdate)
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -93,18 +93,21 @@ kotlin {
 android {
     namespace = "dev.yuyuyuyuyu.portfolio"
     compileSdk =
-        libs.versions.android.compileSdk
+        providers
+            .gradleProperty("android.compileSdk")
             .get()
             .toInt()
 
     defaultConfig {
         applicationId = "dev.yuyuyuyuyu.portfolio"
         minSdk =
-            libs.versions.android.minSdk
+            providers
+                .gradleProperty("android.minSdk")
                 .get()
                 .toInt()
         targetSdk =
-            libs.versions.android.targetSdk
+            providers
+                .gradleProperty("android.targetSdk")
                 .get()
                 .toInt()
         versionCode = 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,9 @@ org.gradle.configuration-cache=true
 org.gradle.caching=true
 
 #Android
+android.compileSdk=37
+android.minSdk=24
+android.targetSdk=36
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 android.defaults.buildfeatures.resvalues=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,6 @@
 [versions]
 aboutlibraries = "15.0.3"
 agp = "9.2.0"
-# @keep read through the libs.versions.android.* accessors, so no library or plugin references it here
-android-compileSdk = "37"
-# @keep read through the libs.versions.android.* accessors, so no library or plugin references it here
-android-minSdk = "24"
-# @keep read through the libs.versions.android.* accessors, so no library or plugin references it here
-android-targetSdk = "36"
 androidx-activity = "1.13.0"
 androidx-appcompat = "1.7.1"
 androidx-core = "1.18.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,11 @@
 [versions]
 aboutlibraries = "15.0.3"
 agp = "9.2.0"
+# @keep read through the libs.versions.android.* accessors, so no library or plugin references it here
 android-compileSdk = "37"
+# @keep read through the libs.versions.android.* accessors, so no library or plugin references it here
 android-minSdk = "24"
+# @keep read through the libs.versions.android.* accessors, so no library or plugin references it here
 android-targetSdk = "36"
 androidx-activity = "1.13.0"
 androidx-appcompat = "1.7.1"
@@ -21,10 +24,10 @@ kotlinxSerialization = "1.11.0"
 ksp = "2.3.9"
 ktlint = "14.2.0"
 material3 = "1.12.0-alpha02"
-version-catalog-update = "1.1.0"
 multiplatform-nav3-ui = "1.1.1"
-simpleTopAppBar = "0.4.0"
 myMaterialTheme = "0.4.0"
+simpleTopAppBar = "0.4.0"
+version-catalog-update = "1.1.0"
 
 [libraries]
 aboutlibraries-compose = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutlibraries" }
@@ -51,8 +54,8 @@ kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.
 kotlinInject-compiler = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlin-inject" }
 kotlinInject-runtime = { module = "me.tatarka.inject:kotlin-inject-runtime-kmp", version.ref = "kotlin-inject" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-yuyuyuyuyu-simpleTopAppBar = { group = "dev.yuyuyuyuyu", name = "simpletopappbar", version.ref = "simpleTopAppBar" }
-yuyuyuyuyu-myMaterialTheme = { group = "dev.yuyuyuyuyu", name = "mymaterialtheme", version.ref = "myMaterialTheme" }
+yuyuyuyuyu-myMaterialTheme = { module = "dev.yuyuyuyuyu:mymaterialtheme", version.ref = "myMaterialTheme" }
+yuyuyuyuyu-simpleTopAppBar = { module = "dev.yuyuyuyuyu:simpletopappbar", version.ref = "simpleTopAppBar" }
 
 [plugins]
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ kotlinxSerialization = "1.11.0"
 ksp = "2.3.9"
 ktlint = "14.2.0"
 material3 = "1.12.0-alpha02"
+version-catalog-update = "1.1.0"
 multiplatform-nav3-ui = "1.1.1"
 simpleTopAppBar = "0.4.0"
 myMaterialTheme = "0.4.0"
@@ -64,3 +65,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "version-catalog-update" }


### PR DESCRIPTION
## What

- Add the [version-catalog-update-plugin](https://github.com/littlerobots/version-catalog-update-plugin) (`nl.littlerobots.version-catalog-update`, v1.1.0) to help keep `gradle/libs.versions.toml` up to date.
- Add a CI job that verifies the version catalog stays canonically formatted.
- Move the Android SDK levels out of the version catalog into `gradle.properties`.

## Why

The version catalog is currently maintained by hand. This plugin adds tasks to detect and apply dependency updates and to keep the catalog tidy, reducing the manual effort of bumping versions. The CI check guards that the catalog does not drift out of its canonical (sorted, formatted) shape as people edit it.

## How

### Introducing the plugin (fit to standard)

Following a "fit to standard" philosophy, the plugin is wired in with as little configuration as possible:

- Declared the plugin (`versionCatalogUpdate`) and its version (`1.1.0`) in `gradle/libs.versions.toml`.
- Applied it to the root project in `build.gradle.kts`. Unlike the other plugins, it is **not** declared with `apply false`, because it contributes its tasks to the root project, where the catalog lives.
- **No `versionCatalogUpdate { }` configuration block is added.** The plugin's defaults already do the right thing — most notably, sorting the catalog by key is enabled by default, so no override is needed.

As of v1.1.0 the plugin no longer depends on the ben-manes versions plugin, so nothing else needs to be added.

### CI check

- A new `version-catalog` job runs `./gradlew versionCatalogFormat` and then `git diff --exit-code gradle/libs.versions.toml`, failing if formatting produced any change. It joins `ktlint` and `detekt` as a required check that must pass before `deploy`.
- To make the check pass, the catalog is brought into the plugin's canonical form (entries sorted by key, libraries written with the `module` notation).

### Moving the Android SDK levels out of the catalog

`compileSdk` / `minSdk` / `targetSdk` are build configuration, not dependency versions: nothing references them via `version.ref`, each is read in a single place, and they are deliberate policy values rather than something to keep bumped to "latest". Leaving them in the catalog only worked by annotating them with `# @keep` so the update plugin would not prune them as unused.

They are moved to the `#Android` section of `gradle.properties`, alongside the project's other `android.*` build settings, and read with the configuration-cache friendly `providers.gradleProperty(...)` accessor. This removes the `# @keep` workaround and leaves the catalog holding only real dependency coordinates.

## New tasks

Once merged, the following tasks become available:

- `versionCatalogUpdate` — updates `libs.versions.toml` with the latest versions.
- `versionCatalogFormat` — formats (and sorts) `libs.versions.toml`.
- `versionCatalogApplyUpdates` — applies pending updates found by `versionCatalogUpdate`.

## Verification

The full project build targets Gradle 9.6.1, whose distribution download is blocked by this development environment's network policy, so the entire build could not be exercised here. The individual pieces were instead verified with the system Gradle in isolated minimal projects:

- The plugin resolves from the Gradle Plugin Portal and registers the three tasks listed above.
- `versionCatalogFormat` is a no-op against the committed catalog (idempotent) — exactly what the CI check needs to pass — and, with the SDK levels removed, every remaining version entry is referenced by a library or plugin, so nothing is pruned and no `# @keep` is required.
- `providers.gradleProperty("android.compileSdk").get().toInt()` (and the min/target equivalents) resolve to `37` / `24` / `36` from `gradle.properties`.

CI itself downloads Gradle 9.6.1 normally (it is not behind that network policy), so the ktlint/detekt/test/build jobs and the new version-catalog job exercise the real project end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4v4ai82VMtmzvbVA6kViK