### PR TITLE
build: make version catalog sorting explicit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,3 +15,11 @@ plugins {
     // update tasks to this root project, where the catalog lives
     alias(libs.plugins.versionCatalogUpdate)
 }
+
+versionCatalogUpdate {
+    // Keep the catalog sorted alphabetically by key. The plugin already sorts by
+    // default, but we set it explicitly so the intent is documented in the build
+    // and a canonical ordering keeps being enforced even if the plugin ever
+    // changes its default.
+    sortByKey.set(true)
+}


### PR DESCRIPTION
## What

Add an explicit `versionCatalogUpdate { sortByKey.set(true) }` block to the root `build.gradle.kts`.

## Why

The task was to check whether version catalog sorting is enabled and, if not, enable it.

Findings:

- The [`version-catalog-update` plugin](https://github.com/littlerobots/version-catalog-update-plugin) was introduced in #52, and it sorts the catalog by key **by default** (`sortByKey` defaults to `true`).
- `gradle/libs.versions.toml` is already sorted alphabetically in every section (`[versions]`, `[libraries]`, `[plugins]`).

So sorting was already effectively enabled — but only implicitly, through the plugin's default value. This PR makes that intent explicit in the build script so that:

- the sorting policy is discoverable directly in `build.gradle.kts` rather than being an invisible default, and
- the catalog keeps a stable, canonical ordering even if the plugin ever changes its default.

Because the catalog is already sorted, this change produces no diff in `libs.versions.toml`.

## Notes

The `sortByKey.set(true)` Kotlin DSL syntax follows the plugin's official documentation (`sortByKey` is a `Property<Boolean>`).

CI was not run locally: the Gradle distribution download (`services.gradle.org`) is blocked by this environment's egress policy, so the build could not be executed here. The change is configuration-only and relies on documented syntax; please rely on CI for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHufdPux4a2YAAuRqLRfiH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHufdPux4a2YAAuRqLRfiH)_