### PR TITLE
Introduce Prettier with standard defaults

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -20,14 +20,33 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
       - name: Check code formatting (ktlint)
         run: ./gradlew ktlintCheck
+
+  prettier:
+    name: Check code formatting (Prettier)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check code formatting (Prettier)
+        run: npm run format:check
 
   detekt:
     name: Static code analysis (detekt)
@@ -39,8 +58,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -58,8 +77,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -82,8 +101,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -101,8 +120,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -125,11 +144,11 @@ jobs:
     # Deploy only after every check and the build have passed, and only for
     # pushes to main. Pull requests run the checks and the build for
     # verification only.
-    needs: [ ktlint, detekt, version-catalog, test, build ]
+    needs: [ktlint, prettier, detekt, version-catalog, test, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      pages: write    # to deploy to Pages
+      pages: write # to deploy to Pages
       id-token: write # to verify the deployment originates from an appropriate source
     # Allow only one concurrent deployment and let in-progress deployments
     # finish, so a queued run never cancels a deployment that is already live.

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,9 +2,9 @@ name: Dependabot
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   dependabot:
@@ -19,8 +19,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
-          distribution: 'jetbrains'
+          java-version: "21"
+          distribution: "jetbrains"
 
       - name: Send dependencies to Dependabot
         uses: gradle/actions/dependency-submission@v6

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Generated Gradle/Compose build output is not source we hand-edit, so keep the
+# formatter from rewriting compiled artifacts.
+**/build/

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,5 @@
 # Development Rules
 
-- After making code changes, you must always run the formatter: `./gradlew ktlintFormat`
+- After making code changes, you must always run the formatters:
+  - Kotlin: `./gradlew ktlintFormat`
+  - Everything else (HTML, CSS, YAML, Markdown, JSON): `npm run format`

--- a/composeApp/src/webMain/resources/index.html
+++ b/composeApp/src/webMain/resources/index.html
@@ -1,20 +1,47 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portfolio</title>
-    <link type="text/css" rel="stylesheet" href="styles.css">
-</head>
-<body style="text-align: center; align-content: center">
-<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 50 50" role="presentation">
-    <circle cx="25" cy="25" r="20" stroke="#ccc" stroke-width="4" fill="none"/>
-    <circle cx="25" cy="25" r="20" stroke="#333" stroke-width="4" fill="none" stroke-linecap="round"
-            stroke-dasharray="90 125">
-        <animateTransform attributeName="transform" type="rotate" from="0 25 25" to="360 25 25" dur="1s"
-                          repeatCount="indefinite"/>
-    </circle>
-</svg>
-<script type="application/javascript" src="composeApp.js"></script>
-</body>
+    <link type="text/css" rel="stylesheet" href="styles.css" />
+  </head>
+  <body style="text-align: center; align-content: center">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="40"
+      height="40"
+      viewBox="0 0 50 50"
+      role="presentation"
+    >
+      <circle
+        cx="25"
+        cy="25"
+        r="20"
+        stroke="#ccc"
+        stroke-width="4"
+        fill="none"
+      />
+      <circle
+        cx="25"
+        cy="25"
+        r="20"
+        stroke="#333"
+        stroke-width="4"
+        fill="none"
+        stroke-linecap="round"
+        stroke-dasharray="90 125"
+      >
+        <animateTransform
+          attributeName="transform"
+          type="rotate"
+          from="0 25 25"
+          to="360 25 25"
+          dur="1s"
+          repeatCount="indefinite"
+        />
+      </circle>
+    </svg>
+    <script type="application/javascript" src="composeApp.js"></script>
+  </body>
 </html>

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -1,7 +1,8 @@
-html, body {
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    overflow: hidden;
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -7,13 +7,13 @@ complexity:
   LongParameterList:
     ignoreDefaultParameters: true
   TooManyFunctions:
-    ignoreAnnotatedFunctions: ['Preview']
+    ignoreAnnotatedFunctions: ["Preview"]
 
 naming:
   FunctionNaming:
-    ignoreAnnotated: ['Composable']
+    ignoreAnnotated: ["Composable"]
   TopLevelPropertyNaming:
-    constantPattern: '[A-Z][A-Za-z0-9]*'
+    constantPattern: "[A-Z][A-Za-z0-9]*"
 
 style:
   MagicNumber:
@@ -22,4 +22,4 @@ style:
     # Line length is enforced by ktlint (140 in the ktlint_official code style).
     active: false
   UnusedPrivateMember:
-    ignoreAnnotated: ['Preview']
+    ignoreAnnotated: ["Preview"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "portfolio",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "portfolio",
+      "devDependencies": {
+        "prettier": "3.9.4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "portfolio",
+  "private": true,
+  "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "prettier": "3.9.4"
+  }
+}


### PR DESCRIPTION
## Summary

Adopts [Prettier](https://prettier.io/) to format the files that the existing Kotlin tooling does not cover: **HTML, CSS, YAML, Markdown and JSON**. ktlint keeps handling Kotlin and the `versionCatalogFormat` task keeps handling `libs.versions.toml`, so Prettier simply fills the remaining gap and gives every file type an automated, canonical style.

## "Fit to standard"

This is a deliberately minimal adoption:

- **No `.prettierrc`** — Prettier runs entirely on its [built-in defaults](https://prettier.io/docs/options) instead of a hand-tuned house style.
- The only non-style config is a small `.prettierignore` that keeps the formatter away from generated Gradle/Compose build output.

## A note on sorting

The request asked to enable sorting if Prettier has it off by default. Prettier's core ships **no sorting of its own** — its only sort-on-format capability is the third-party import-sorting plugins for JavaScript/TypeScript. This repository has no hand-written JS/TS (the web target is compiled from Kotlin), so there is nothing for such a plugin to act on, and none is added. That keeps the setup free of configuration that would format zero files.

## What changed

- **Tooling**: `package.json` (with `format` / `format:check` scripts and Prettier pinned as a dev dependency), `package-lock.json`, and `.prettierignore`.
- **Reformatted to Prettier defaults**: `index.html`, `styles.css`, the two workflow files, and `detekt.yml`. These are purely mechanical formatting changes (indentation, quote style, self-closing tags, trailing newlines).
- **CI enforcement**: a new `prettier` check job in `ci-cd.yml` that mirrors the existing ktlint job, wired into the `deploy` job's prerequisites.
- **Dependency updates**: Dependabot now tracks the `npm` ecosystem so Prettier stays current alongside Gradle and GitHub Actions.
- **Docs**: `GEMINI.md` now points contributors at `npm run format` for non-Kotlin files.

## Verification

- `npm run format:check` — all matched files use Prettier code style.
- `npm ci` — installs cleanly from the committed lockfile (matches what CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3ELcpp6NufikcNfUZagpF

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3ELcpp6NufikcNfUZagpF)_