### PR TITLE
ci: pass GITHUB_TOKEN to setup-java jetbrains distribution

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           java-version: "21"
           distribution: "jetbrains"
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -60,6 +64,10 @@ jobs:
         with:
           java-version: "21"
           distribution: "jetbrains"
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -79,6 +87,10 @@ jobs:
         with:
           java-version: "21"
           distribution: "jetbrains"
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -103,6 +115,10 @@ jobs:
         with:
           java-version: "21"
           distribution: "jetbrains"
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -122,6 +138,10 @@ jobs:
         with:
           java-version: "21"
           distribution: "jetbrains"
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,6 +21,10 @@ jobs:
         with:
           java-version: "21"
           distribution: "jetbrains"
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Send dependencies to Dependabot
         uses: gradle/actions/dependency-submission@v6


### PR DESCRIPTION
The JetBrains JDK distribution resolves its version through the GitHub
API, which is throttled to 60 requests/hour/IP for unauthenticated
callers. Under that limit the Setup JDK step intermittently fails, so
authenticate every JetBrains setup-java step with the workflow token.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PW9y3Bjy7thtqQY8jve4BJ