### PR TITLE
ci: add a scheduled workflow that updates the Wasm yarn.lock

### DIFF
--- a/.github/workflows/update-wasm-yarn-lock.yml
+++ b/.github/workflows/update-wasm-yarn-lock.yml
@@ -1,0 +1,78 @@
+name: Update Wasm yarn.lock
+
+on:
+  schedule:
+    # Offset from the top of the hour because GitHub drops or delays scheduled
+    # runs that land in its busiest windows.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One run at a time, because concurrent runs would race each other force
+# pushing the same pull request branch.
+concurrency:
+  group: update-wasm-yarn-lock
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update Wasm yarn.lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "jetbrains"
+        # The JetBrains distribution resolves its version via the GitHub API;
+        # authenticate so it isn't throttled by the 60 req/hour/IP limit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+
+      # This task only regenerates kotlin-js-store/wasm/yarn.lock. The JS
+      # target keeps its own kotlin-js-store/yarn.lock, which stays untouched.
+      - name: Upgrade Wasm yarn.lock
+        run: ./gradlew kotlinWasmUpgradeYarnLock
+
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.PR_BOT_APP_ID }}
+          private-key: ${{ secrets.PR_BOT_PRIVATE_KEY }}
+
+      # The pull request is opened with the App token rather than the default
+      # GITHUB_TOKEN, so that the CI/CD workflow actually runs on it and the
+      # refreshed lock file gets verified before merging.
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          # Committing this one path keeps the JS lock file out of the pull
+          # request even if some other task rewrites it along the way.
+          add-paths: kotlin-js-store/wasm/yarn.lock
+          branch: chore/update-wasm-yarn-lock
+          commit-message: "build(deps): update Wasm yarn.lock"
+          # Route the commit through the API so it is attributed to the App and
+          # signed, instead of to whoever happens to trigger the run.
+          sign-commits: true
+          title: "build(deps): update Wasm yarn.lock"
+          body: |
+            The Wasm target resolves its npm dependencies through
+            `kotlin-js-store/wasm/yarn.lock`. This pull request is the output of
+            `./gradlew kotlinWasmUpgradeYarnLock`, opened automatically because the
+            resolved versions have moved since the lock file was last committed.
+
+            The JS target's `kotlin-js-store/yarn.lock` is left alone on purpose.
+          labels: dependencies
+          # Close the pull request and drop the branch once the lock file no
+          # longer differs from main, instead of leaving a stale one open.
+          delete-branch: true


### PR DESCRIPTION
## What

Adds `.github/workflows/update-wasm-yarn-lock.yml`, a workflow that runs `./gradlew kotlinWasmUpgradeYarnLock` daily (and on demand via `workflow_dispatch`) and opens a pull request whenever the resolved npm versions have moved. When nothing changed, no pull request is created.

## Why

The Wasm target's npm dependencies are pinned in `kotlin-js-store/wasm/yarn.lock`, which until now only moved when someone remembered to run the Gradle task by hand. Dependabot covers Gradle, GitHub Actions and npm, but it does not manage the lock file the Kotlin Gradle plugin generates, so this closes that gap.

## Notes for the reviewer

- **The JS lock file is untouched, and that is enforced twice.** `kotlinWasmUpgradeYarnLock` only rewrites `kotlin-js-store/wasm/yarn.lock` (verified by running it locally against the current tree), and `add-paths` limits the commit to that single file as a second line of defence, so `kotlin-js-store/yarn.lock` cannot end up in the pull request.
- **The pull request is opened with a `yuyuyuyuyu-dev-pr-bot` App token, not the default `GITHUB_TOKEN`.** A pull request opened with `GITHUB_TOKEN` does not trigger other workflows, which would leave the refreshed lock file unverified by CI/CD before merge. `sign-commits: true` routes the commit through the API, so it is signed and attributed to the App rather than to whoever happens to trigger the run.
- The branch name is fixed, so a re-run updates the open pull request instead of stacking up new ones. `delete-branch: true` closes it and drops the branch once the lock file no longer differs from `main`.
- A `concurrency` group prevents a manual run and the scheduled run from racing each other force pushing the same branch.
- The cron is offset from the top of the hour because GitHub delays or drops scheduled runs that land in its busiest windows.

## Required setup before this can run

The repository currently has no secrets configured. This workflow stays inert until:

1. `PR_BOT_APP_ID` and `PR_BOT_PRIVATE_KEY` are added as repository secrets.
2. The App has `Contents: Read & write` and `Pull requests: Read & write` repository permissions (`Workflows` is not needed, since the pull request only ever touches a lock file).
3. The App is installed on this repository.

## Verification

`actionlint` passes on the new workflow, `npm run format:check` is clean, and `./gradlew kotlinWasmUpgradeYarnLock` was run locally to confirm it succeeds and leaves the JS lock file alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)