### PR TITLE
ci: group and auto-merge Dependabot minor and patch updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @yuyuyuyuyu-dev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,36 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+
+# Dependabot's own pull_request runs get a read-only token and no access to the
+# Actions secrets, so the App credentials are only reachable through
+# pull_request_target, which runs this file as it exists on main.
+on:
+  pull_request_target:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    name: Auto-merge
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      # This step fails when the pull request carries commits that Dependabot
+      # did not sign, which leaves every later step skipped.
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+
+      - name: Create GitHub App token
+        id: app-token
+        if: contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type)
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.PR_BOT_APP_ID }}
+          private-key: ${{ secrets.PR_BOT_PRIVATE_KEY }}
+
+      # Auto-merge is enabled with the App token rather than the default
+      # GITHUB_TOKEN, so that the merge into main triggers the CI/CD workflow
+      # and the site is actually deployed.
+      - name: Enable auto-merge
+        if: contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## What

Collects every minor and patch update into a single `minor-and-patch` group per ecosystem (`gradle`, `github-actions`, `npm`), and adds `.github/workflows/dependabot-auto-merge.yml`, which turns on auto-merge with squashing for those grouped pull requests as soon as Dependabot opens them. Major updates keep opening their own pull request and are never auto-merged.

Also removes `.github/CODEOWNERS`.

## Why

Dependabot opens one pull request per dependency today, and every one of them has to be merged by hand even though minor and patch updates are almost always uneventful. Grouping them means at most one pull request per ecosystem per day, and auto-merge means it lands on its own once the required checks pass. Major updates still deserve a read, so they stay separate and manual.

`CODEOWNERS` made the only owner of this repository a reviewer of every pull request. No rule requires an approving review, so the one thing it still did was ask for a review on the dependency updates that now merge on their own.

## Notes for the reviewer

- **The workflow listens for `pull_request_target`, not `pull_request`.** Dependabot's own `pull_request` runs get a read-only token and cannot read the Actions secrets that hold the App credentials. Nothing from the pull request is checked out or run — the job only calls `gh` — so the elevated context never touches code that Dependabot proposes.
- **Auto-merge is enabled with a `yuyuyuyuyu-dev-pr-bot` App token, not the default `GITHUB_TOKEN`.** A merge made with `GITHUB_TOKEN` does not start another workflow run, so CI/CD would never run on `main` and the site would never be deployed.
- `dependabot/fetch-metadata` fails when the pull request carries commits that Dependabot did not sign, which leaves both later steps skipped. That is what stops a pull request with hand-pushed commits from merging itself.
- The update type is matched against an explicit list of `version-update:semver-minor` and `version-update:semver-patch` rather than against "anything that is not major", so an empty or unexpected value never merges.
- For a grouped pull request, `update-type` reports the highest change in the group. The group only ever holds minor and patch updates, so it can never report major.
- Security updates are not grouped, because `applies-to` defaults to `version-updates`. A minor or patch security update still auto-merges as its own pull request.
- `open-pull-requests-limit: 1` is left alone. A major pull request waiting for review holds back the grouped one, which was already the case before this change.

## Required setup

1. **Done.** `Allow auto-merge` is enabled in the repository settings. Without it `gh pr merge --auto` fails.
2. The App needs `Contents: Read & write` and `Pull requests: Read & write`, the same permissions it already uses to open the Wasm lock file pull requests.
3. `Check code formatting (Prettier)` and `Check version catalog formatting` are not required checks in the `main` ruleset, so auto-merge does not wait for them. A Prettier bump that changes formatting, or a `libs.versions.toml` edit that `versionCatalogFormat` would rewrite, can merge while red. Both are worth adding to the ruleset. They are missing from the ruleset picker because it only lists checks reported in the last week, and opening this pull request puts them back in that window.
4. `pull_request_target` runs the definition that sits on `main`, so auto-merge starts working on the first Dependabot pull request opened after this is merged.

## Verification

`actionlint` passes on the new workflow and `npm run format:check` is clean. The configuration was checked against the repository's real state: the `main` ruleset requires four checks and no approving review, squash merging is allowed, and `PR_BOT_APP_ID` and `PR_BOT_PRIVATE_KEY` are already present as Actions secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
